### PR TITLE
feat: add margin-bottom to side-dock-settings for improved spacing

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1441,6 +1441,10 @@ body.is-focused .workspace-ribbon.mod-left {
 	border: none;
 }
 
+.side-dock-settings {
+	margin-bottom: 9px;
+}
+
 .side-dock-settings .side-dock-ribbon-action,
 .side-dock-actions .side-dock-ribbon-action {
 	margin: 0 auto;


### PR DESCRIPTION
现有旧版工具布局位置偏下，修改进行了上移，与默认主题在视觉和使用上保持一致
![250323_203049_RavenHogwarts](https://github.com/user-attachments/assets/cdbb8c4d-be56-449c-9df4-340dfe81a219)
